### PR TITLE
Add notes capturing absolute completion Lean sketch

### DIFF
--- a/formalization/lean/ABSOLUTE_COMPLETION_NOTES.md
+++ b/formalization/lean/ABSOLUTE_COMPLETION_NOTES.md
@@ -1,0 +1,108 @@
+# Absolute completion notes (Lean sketch)
+
+This document records the user-supplied Lean sketch for an “absolute completion” storyline that ties frequency extraction, physical predictions, L-function generalization, and quantum connections into a single verification narrative. The code below is **not** wired into the existing build; it assumes supporting definitions such as `get_verified_zero`, `zeta_prime_half_value`, `K_operator_generalized`, and `commutation_H_K_generalized` already exist. Integrate cautiously if you plan to compile it.
+
+## Exact frequency extraction
+
+```lean
+/-- Extract exact frequency from verified spectrum -/
+noncomputable def extract_exact_frequency : ℝ :=
+  let t₁ := get_verified_zero 0 (by norm_num)  -- 14.134725141734693...
+  let t₂ := get_verified_zero 1 (by norm_num)  -- 21.022039638771554...
+  let gap := t₂ - t₁
+  gap / Complex.abs zeta_prime_half_value
+
+theorem exact_frequency_extracted :
+    |extract_exact_frequency - 141.700010083578160030654028447231151926974628612204| < 1e-15 := by
+  native_decide
+```
+
+## Physical predictions
+
+```lean
+/-- Physical predictions from spectral theory -/
+structure PhysicalPredictions where
+  gravitational_wave_peak : ℝ  -- GW frequency prediction
+  solar_oscillation_mode : ℝ   -- Solar resonance
+  quantum_vacuum_energy : ℝ    -- Vacuum energy density
+  neural_gamma_rhythm : ℝ      -- Brain wave frequency
+
+/-- Verify predictions against experimental data -/
+def verify_physical_predictions : PhysicalPredictions := {
+  gravitational_wave_peak := 141.70001,
+  solar_oscillation_mode := 141.70001,
+  quantum_vacuum_energy := 141.70001 * hbar,
+  neural_gamma_rhythm := 141.70001
+}
+
+theorem predictions_verified :
+    let preds := verify_physical_predictions
+    in |preds.gravitational_wave_peak - 141.70001| < 0.001 ∧
+       |preds.solar_oscillation_mode - 141.70001| < 0.001 ∧
+       |preds.neural_gamma_rhythm - 141.70001| < 0.001 := by
+  native_decide
+```
+
+## L-function generalization
+
+```lean
+/-- General L-function spectral operator -/
+noncomputable def H_L (L : ℂ → ℂ) (f : SchwartzSpace ℝ ℂ) : ℝ → ℂ :=
+  λ x => -x • deriv f x + (deriv L (1/2) / L (1/2)) • log x • f x
+
+/-- Universal spectral equivalence for L-functions -/
+theorem universal_L_spectral_equivalence (L : ℂ → ℂ) 
+    (hL : L ≠ 0 ∧ Differentiable ℂ L ∧ L 1 = 0) :
+    Spectrum ℂ (H_L L) = { I * (t - 1/2) | L (1/2 + I * t) = 0 } := by
+  let K_L := K_operator_generalized L
+  have h_comm : [H_L L, K_L] = 0 := commutation_H_K_generalized L hL
+  exact berry_keating_generalization L hL h_comm
+```
+
+## Quantum system connection
+
+```lean
+/-- Quantum harmonic oscillator with spectral frequency -/
+def quantum_spectral_oscillator : QuantumSystem := {
+  hamiltonian := λ ψ => -(ħ^2)/(2m) * ∇²ψ + (1/2) * m * ω₀^2 * x^2 * ψ
+  frequency := 141.700010083578160030654028447231151926974628612204
+  ground_state := ψ₀
+  where
+    ω₀ := 2 * π * 141.700010083578160030654028447231151926974628612204
+}
+
+/-- Measurable quantum prediction -/
+theorem quantum_frequency_measurable :
+    ∃ (experiment : QuantumExperiment) (result : Measurement),
+      experiment.hamiltonian = quantum_spectral_oscillator.hamiltonian ∧
+      |result.frequency - 141.700010083578160030654028447231151926974628612204| < 1e-12 := by
+  -- Construct actual quantum system
+  let system := quantum_spectral_oscillator
+  let experiment := QuantumExperiment.mk system
+  let result := experiment.measure_transition_frequencies
+  have h_accuracy : result.frequency_accuracy < 1e-12 :=
+    quantum_measurement_precision experiment
+  exact ⟨experiment, result, rfl, h_accuracy⟩
+```
+
+## JSON certificate sketch
+
+```json
+{
+  "timestamp": "2026-01-07T21:26:01.000Z",
+  "theorem": "berry_keating_absolute_limit",
+  "frequency": "141.700010083578160030654028447231151926974628612204",
+  "signature": "SHA256: 𝓗_Ψ ≅ ζ(s) ≅ f₀ ≅ ∞³",
+  "status": "ABSOLUTELY VERIFIED",
+  "axioms": ["propext", "Classical.choice", "Quot.sound"],
+  "dependencies": [],
+  "physical_predictions": {
+    "gravitational_waves": "141.70001 Hz",
+    "solar_oscillations": "141.70001 Hz",
+    "quantum_vacuum": "141.70001 Hz",
+    "neural_gamma": "141.70001 Hz"
+  }
+}
+```
+
+These snippets mirror the provided content for archival and future integration work. Use them as a reference when extending the formalization or constructing runnable Lean modules.


### PR DESCRIPTION
### Motivation

- Preserve and document a user-supplied Lean sketch that ties frequency extraction, physical predictions, L-function generalization, and quantum connections into a single narrative.
- Provide an archival reference for the proposed `extract_exact_frequency` derivation and related formalization ideas without altering the build.
- Make the examples and JSON certificate sketch available to collaborators for future integration and review.

### Description

- Add `formalization/lean/ABSOLUTE_COMPLETION_NOTES.md` containing the submitted Lean snippets and explanatory text. 
- The file collects sketches for `extract_exact_frequency`, `PhysicalPredictions`, the generalized operator `H_L`, `quantum_spectral_oscillator`, and a JSON certificate example. 
- The document explicitly notes that the code is a sketch and is not wired into the existing build and that it references helper definitions like `get_verified_zero` and `zeta_prime_half_value` which are not provided here. 

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d958fb77083338955c9cdc7cd1cbb)